### PR TITLE
Update D&D Wiki; Swashbuckler.json

### DIFF
--- a/class/D&D Wiki; Swashbuckler.json
+++ b/class/D&D Wiki; Swashbuckler.json
@@ -743,7 +743,7 @@
 			"name": "Concussive Bomb",
 			"source": "SC",
 			"featureType": [
-				"MB"
+				"TB"
 			],
 			"entries": [
 				"Creates a concussive shock-wave. All creatures within a 60 foot radius that have Line of Sight to the area must succeed on a Dexterity saving throw vs your ability save or be {@condition stunned}. All creatures must make a Wisdom save at the end of each of their turns to snap out of it."
@@ -753,7 +753,7 @@
 			"name": "Fury Bomb",
 			"source": "SC",
 			"featureType": [
-				"MB"
+				"TB"
 			],
 			"entries": [
 				"Releases a cloud of gas. All creatures in a 20ft radius must succeed on a Constitution saving throw vs your ability save or fall under similar effects of the {@spell confusion} spell. All creatures must make a Wisdom save at the end of each of their turns to overcome the gas."
@@ -763,7 +763,7 @@
 			"name": "Incendiary Bomb",
 			"source": "SC",
 			"featureType": [
-				"MB"
+				"TB"
 			],
 			"entries": [
 				"Creates a deadly explosion. All creatures in a 10ft radius must succeed on a Dexterity saving throw vs your ability save or take {@dice 6d10} fire damage, half as much on a successful save."
@@ -773,7 +773,7 @@
 			"name": "Sleep Bomb",
 			"source": "SC",
 			"featureType": [
-				"MB"
+				"TB"
 			],
 			"entries": [
 				"Releases a cloud of gas. All creatures in a 30 foot radius must succeed on a Constitution saving throw vs your ability save or be knocked {@condition unconscious}. All creatures must make a Wisdom save at the end of each of their turns to overcome the gas. A sleeping creature awakens when attacked."
@@ -1296,7 +1296,7 @@
 			"level": 15,
 			"header": 2,
 			"entries": [
-				"Starting at 15th level, you learn to create more powerful {@filter bombs|optionalfeatures|Feature Type=MB}. To create these new bombs you must spend 50 gold pieces and spend 6 hours in a village, town, or city. You are only allowed to have one of each bomb at a time, they are too dangerous to give to others, and cannot be sold without raising suspicion. The radius of affect for all bombs you make with Explosives Expert increases by 5 feet and they may be thrown up to 40 feet. Furthermore, when creating the bombs listed under explosives expert ability, you roll a {@dice d6} plus 2 to determine how many bombs you create."
+				"Starting at 15th level, you learn to create more powerful {@filter bombs|optionalfeatures|Feature Type=TB}. To create these new bombs you must spend 50 gold pieces and spend 6 hours in a village, town, or city. You are only allowed to have one of each bomb at a time, they are too dangerous to give to others, and cannot be sold without raising suspicion. The radius of affect for all bombs you make with Explosives Expert increases by 5 feet and they may be thrown up to 40 feet. Furthermore, when creating the bombs listed under explosives expert ability, you roll a {@dice d6} plus 2 to determine how many bombs you create."
 			]
 		},
 		{


### PR DESCRIPTION
"MB" is incorrect, should be "TB" for "Trickster Bomb" optional feature